### PR TITLE
Update ember-cli-handlebars to fix deprecation warning in Ember 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "copy-dereference": "^1.0.0",
-    "ember-cli-htmlbars": "^0.7.5",
+    "ember-cli-htmlbars": "^1.1.0",
     "promise-map-series": "^0.2.1",
     "rsvp": "^3.0.18",
     "walk-sync": "^0.1.3",


### PR DESCRIPTION
Update ember-cli-handlebars version to >= 1.1.0 to fix the following deprecation warning that shows up after upgrading to Ember 2.6.0:
```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (.../node_modules/ember-cli/lib/models/addon.js:1005:27)
```

Issue outlined here: https://github.com/ember-cli/ember-cli-htmlbars/issues/77